### PR TITLE
Change subscope to be named Datacatalog

### DIFF
--- a/pkg/rpc/datacatalogservice/service.go
+++ b/pkg/rpc/datacatalogservice/service.go
@@ -68,7 +68,7 @@ func (s *DataCatalogService) AddTag(ctx context.Context, request *catalog.AddTag
 func NewDataCatalogService() *DataCatalogService {
 	configProvider := runtime.NewConfigurationProvider()
 	dataCatalogConfig := configProvider.ApplicationConfiguration().GetDataCatalogConfig()
-	catalogScope := promutils.NewScope(dataCatalogConfig.MetricsScope).NewSubScope("service")
+	catalogScope := promutils.NewScope(dataCatalogConfig.MetricsScope).NewSubScope("datacatalog")
 	ctx := contextutils.WithAppName(context.Background(), "datacatalog")
 
 	// Set Keys


### PR DESCRIPTION
Change the subscope of the metrics to be `datacatalog` instead of generic `service`. This is because the top level `metricScope` can be namespaced anything. So we should allow clients to use a `metricScope` that does not have to dictate `datacatalog`. 