### PR TITLE
Metrics cleanup

### DIFF
--- a/pkg/manager/impl/artifact_data_store.go
+++ b/pkg/manager/impl/artifact_data_store.go
@@ -37,7 +37,7 @@ func (m *artifactDataStore) PutData(ctx context.Context, artifact datacatalog.Ar
 	}
 	err = m.store.WriteProtobuf(ctx, dataLocation, storage.Options{}, data.Value)
 	if err != nil {
-		return "", errors.NewDataCatalogErrorf(codes.Internal, "Unable to store artifact data in location %s, value %v, err %v", dataLocation.String(), data.Value, err)
+		return "", errors.NewDataCatalogErrorf(codes.Internal, "Unable to store artifact data in location %s, err %v", dataLocation.String(), err)
 	}
 
 	return dataLocation, nil

--- a/pkg/manager/impl/artifact_manager.go
+++ b/pkg/manager/impl/artifact_manager.go
@@ -186,12 +186,12 @@ func (m *artifactManager) GetArtifact(ctx context.Context, request datacatalog.G
 func NewArtifactManager(repo repositories.RepositoryInterface, store *storage.DataStore, storagePrefix storage.DataReference, artifactScope promutils.Scope) interfaces.ArtifactManager {
 	artifactMetrics := artifactMetrics{
 		scope:                    artifactScope,
-		createSuccessCounter:     labeled.NewCounter("create_artifact_success_count", "The number of times create artifact was called", artifactScope, labeled.EmitUnlabeledMetric),
-		getSuccessCounter:        labeled.NewCounter("get_artifact_success_count", "The number of times get artifact was called", artifactScope, labeled.EmitUnlabeledMetric),
-		createFailureCounter:     labeled.NewCounter("create_artifact_failure_count", "The number of times create artifact failed", artifactScope, labeled.EmitUnlabeledMetric),
-		getFailureCounter:        labeled.NewCounter("get_artifact_failure_count", "The number of times get artifact failed", artifactScope, labeled.EmitUnlabeledMetric),
-		createDataFailureCounter: labeled.NewCounter("create_artifact_data_failure_count", "The number of times create artifact data failed", artifactScope, labeled.EmitUnlabeledMetric),
-		createDataSuccessCounter: labeled.NewCounter("create_artifact_data_succeeded_count", "The number of times create artifact data succeeded", artifactScope, labeled.EmitUnlabeledMetric),
+		createSuccessCounter:     labeled.NewCounter("create_success_count", "The number of times create artifact was called", artifactScope, labeled.EmitUnlabeledMetric),
+		getSuccessCounter:        labeled.NewCounter("get_success_count", "The number of times get artifact was called", artifactScope, labeled.EmitUnlabeledMetric),
+		createFailureCounter:     labeled.NewCounter("create_failure_count", "The number of times create artifact failed", artifactScope, labeled.EmitUnlabeledMetric),
+		getFailureCounter:        labeled.NewCounter("get_failure_count", "The number of times get artifact failed", artifactScope, labeled.EmitUnlabeledMetric),
+		createDataFailureCounter: labeled.NewCounter("create_data_failure_count", "The number of times create artifact data failed", artifactScope, labeled.EmitUnlabeledMetric),
+		createDataSuccessCounter: labeled.NewCounter("create_data_succeeded_count", "The number of times create artifact data succeeded", artifactScope, labeled.EmitUnlabeledMetric),
 		transformerErrorCounter:  labeled.NewCounter("transformer_failed_count", "The number of times transformations failed", artifactScope, labeled.EmitUnlabeledMetric),
 		validationErrorCounter:   labeled.NewCounter("validation_failed_count", "The number of times validation failed", artifactScope, labeled.EmitUnlabeledMetric),
 		alreadyExistsCounter:     labeled.NewCounter("already_exists_count", "The number of times an artifact already exists", artifactScope, labeled.EmitUnlabeledMetric),

--- a/pkg/manager/impl/artifact_manager.go
+++ b/pkg/manager/impl/artifact_manager.go
@@ -202,7 +202,7 @@ func NewArtifactManager(repo repositories.RepositoryInterface, store *storage.Da
 		createFailureCounter:     labeled.NewCounter("create_failure_count", "The number of times create artifact failed", artifactScope, labeled.EmitUnlabeledMetric),
 		getFailureCounter:        labeled.NewCounter("get_failure_count", "The number of times get artifact failed", artifactScope, labeled.EmitUnlabeledMetric),
 		createDataFailureCounter: labeled.NewCounter("create_data_failure_count", "The number of times create artifact data failed", artifactScope, labeled.EmitUnlabeledMetric),
-		createDataSuccessCounter: labeled.NewCounter("create_data_succeeded_count", "The number of times create artifact data succeeded", artifactScope, labeled.EmitUnlabeledMetric),
+		createDataSuccessCounter: labeled.NewCounter("create_data_success_count", "The number of times create artifact data succeeded", artifactScope, labeled.EmitUnlabeledMetric),
 		transformerErrorCounter:  labeled.NewCounter("transformer_failed_count", "The number of times transformations failed", artifactScope, labeled.EmitUnlabeledMetric),
 		validationErrorCounter:   labeled.NewCounter("validation_failed_count", "The number of times validation failed", artifactScope, labeled.EmitUnlabeledMetric),
 		alreadyExistsCounter:     labeled.NewCounter("already_exists_count", "The number of times an artifact already exists", artifactScope, labeled.EmitUnlabeledMetric),

--- a/pkg/manager/impl/tag_manager.go
+++ b/pkg/manager/impl/tag_manager.go
@@ -75,9 +75,9 @@ func (m *tagManager) AddTag(ctx context.Context, request datacatalog.AddTagReque
 func NewTagManager(repo repositories.RepositoryInterface, store *storage.DataStore, tagScope promutils.Scope) interfaces.TagManager {
 	systemMetrics := tagMetrics{
 		scope:                  tagScope,
-		addTagSuccessCounter:   labeled.NewCounter("add_tag_success_count", "The number of times an artifact was tagged successfully", tagScope, labeled.EmitUnlabeledMetric),
-		addTagFailureCounter:   labeled.NewCounter("add_tag_failure_count", "The number of times we failed  to tag an artifact", tagScope, labeled.EmitUnlabeledMetric),
-		validationErrorCounter: labeled.NewCounter("validation_error_count", "The number of times we failed validate a tag", tagScope, labeled.EmitUnlabeledMetric),
+		addTagSuccessCounter:   labeled.NewCounter("create_success_count", "The number of times an artifact was tagged successfully", tagScope, labeled.EmitUnlabeledMetric),
+		addTagFailureCounter:   labeled.NewCounter("create_failure_count", "The number of times we failed  to tag an artifact", tagScope, labeled.EmitUnlabeledMetric),
+		validationErrorCounter: labeled.NewCounter("validation_failed_count", "The number of times we failed validate a tag", tagScope, labeled.EmitUnlabeledMetric),
 		alreadyExistsCounter:   labeled.NewCounter("already_exists_count", "The number of times an tag already exists", tagScope, labeled.EmitUnlabeledMetric),
 	}
 

--- a/pkg/manager/impl/tag_manager.go
+++ b/pkg/manager/impl/tag_manager.go
@@ -2,6 +2,7 @@ package impl
 
 import (
 	"context"
+	"time"
 
 	"github.com/lyft/datacatalog/pkg/manager/impl/validators"
 	"github.com/lyft/datacatalog/pkg/manager/interfaces"
@@ -21,6 +22,7 @@ import (
 
 type tagMetrics struct {
 	scope                  promutils.Scope
+	createResponseTime     labeled.StopWatch
 	addTagSuccessCounter   labeled.Counter
 	addTagFailureCounter   labeled.Counter
 	validationErrorCounter labeled.Counter
@@ -34,6 +36,9 @@ type tagManager struct {
 }
 
 func (m *tagManager) AddTag(ctx context.Context, request datacatalog.AddTagRequest) (*datacatalog.AddTagResponse, error) {
+	timer := m.systemMetrics.createResponseTime.Start(ctx)
+	defer timer.Stop()
+
 	if err := validators.ValidateTag(request.Tag); err != nil {
 		logger.Warnf(ctx, "Invalid get tag request %+v err: %v", request, err)
 		m.systemMetrics.validationErrorCounter.Inc(ctx)
@@ -75,6 +80,7 @@ func (m *tagManager) AddTag(ctx context.Context, request datacatalog.AddTagReque
 func NewTagManager(repo repositories.RepositoryInterface, store *storage.DataStore, tagScope promutils.Scope) interfaces.TagManager {
 	systemMetrics := tagMetrics{
 		scope:                  tagScope,
+		createResponseTime:     labeled.NewStopWatch("create_duration", "The duration of the add tag calls.", time.Millisecond, tagScope, labeled.EmitUnlabeledMetric),
 		addTagSuccessCounter:   labeled.NewCounter("create_success_count", "The number of times an artifact was tagged successfully", tagScope, labeled.EmitUnlabeledMetric),
 		addTagFailureCounter:   labeled.NewCounter("create_failure_count", "The number of times we failed  to tag an artifact", tagScope, labeled.EmitUnlabeledMetric),
 		validationErrorCounter: labeled.NewCounter("validation_failed_count", "The number of times we failed validate a tag", tagScope, labeled.EmitUnlabeledMetric),

--- a/pkg/rpc/datacatalogservice/service.go
+++ b/pkg/rpc/datacatalogservice/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
-	"time"
 
 	"github.com/lyft/datacatalog/pkg/manager/impl"
 	"github.com/lyft/datacatalog/pkg/manager/interfaces"
@@ -20,48 +19,29 @@ import (
 	"github.com/lyft/flytestdlib/storage"
 )
 
-type serviceMetrics struct {
-	createDatasetResponseTime  labeled.StopWatch
-	getDatasetResponseTime     labeled.StopWatch
-	createArtifactResponseTime labeled.StopWatch
-	getArtifactResponseTime    labeled.StopWatch
-	addTagResponseTime         labeled.StopWatch
-}
-
 type DataCatalogService struct {
 	DatasetManager  interfaces.DatasetManager
 	ArtifactManager interfaces.ArtifactManager
 	TagManager      interfaces.TagManager
-	serviceMetrics  serviceMetrics
 }
 
 func (s *DataCatalogService) CreateDataset(ctx context.Context, request *catalog.CreateDatasetRequest) (*catalog.CreateDatasetResponse, error) {
-	timer := s.serviceMetrics.createDatasetResponseTime.Start(ctx)
-	defer timer.Stop()
 	return s.DatasetManager.CreateDataset(ctx, *request)
 }
 
 func (s *DataCatalogService) CreateArtifact(ctx context.Context, request *catalog.CreateArtifactRequest) (*catalog.CreateArtifactResponse, error) {
-	timer := s.serviceMetrics.createArtifactResponseTime.Start(ctx)
-	defer timer.Stop()
 	return s.ArtifactManager.CreateArtifact(ctx, *request)
 }
 
 func (s *DataCatalogService) GetDataset(ctx context.Context, request *catalog.GetDatasetRequest) (*catalog.GetDatasetResponse, error) {
-	timer := s.serviceMetrics.getDatasetResponseTime.Start(ctx)
-	defer timer.Stop()
 	return s.DatasetManager.GetDataset(ctx, *request)
 }
 
 func (s *DataCatalogService) GetArtifact(ctx context.Context, request *catalog.GetArtifactRequest) (*catalog.GetArtifactResponse, error) {
-	timer := s.serviceMetrics.getArtifactResponseTime.Start(ctx)
-	defer timer.Stop()
 	return s.ArtifactManager.GetArtifact(ctx, *request)
 }
 
 func (s *DataCatalogService) AddTag(ctx context.Context, request *catalog.AddTagRequest) (*catalog.AddTagResponse, error) {
-	timer := s.serviceMetrics.addTagResponseTime.Start(ctx)
-	defer timer.Stop()
 	return s.TagManager.AddTag(ctx, *request)
 }
 
@@ -122,12 +102,5 @@ func NewDataCatalogService() *DataCatalogService {
 		DatasetManager:  impl.NewDatasetManager(repos, dataStorageClient, catalogScope.NewSubScope("dataset")),
 		ArtifactManager: impl.NewArtifactManager(repos, dataStorageClient, storagePrefix, catalogScope.NewSubScope("artifact")),
 		TagManager:      impl.NewTagManager(repos, dataStorageClient, catalogScope.NewSubScope("tag")),
-		serviceMetrics: serviceMetrics{
-			createDatasetResponseTime:  labeled.NewStopWatch("create_dataset_duration", "The duration of the create artifact calls.", time.Millisecond, catalogScope, labeled.EmitUnlabeledMetric),
-			getDatasetResponseTime:     labeled.NewStopWatch("get_dataset_duration", "The duration of the get artifact calls.", time.Millisecond, catalogScope, labeled.EmitUnlabeledMetric),
-			createArtifactResponseTime: labeled.NewStopWatch("create_artifact_duration", "The duration of the get artifact calls.", time.Millisecond, catalogScope, labeled.EmitUnlabeledMetric),
-			getArtifactResponseTime:    labeled.NewStopWatch("get_artifact_duration", "The duration of the get artifact calls.", time.Millisecond, catalogScope, labeled.EmitUnlabeledMetric),
-			addTagResponseTime:         labeled.NewStopWatch("add_tag_duration", "The duration of the get artifact calls.", time.Millisecond, catalogScope, labeled.EmitUnlabeledMetric),
-		},
 	}
 }


### PR DESCRIPTION
This PR cleans up the metric names between the entities so they are named with a common convention of:
```
create_duration
get_duration
create_success_count
get_success_count
create_failure_count
get_failure_count
```

This helps when viewing metrics through the dashboard.