### PR TITLE
Remove dockerhub push travis step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,6 @@ jobs:
       name: docker build
       install: true
       script: make docker_build
-    - if: fork = false
-      stage: test
-      name: docker build and push
-      install: true
-      script: make dockerhub_push
     - stage: test
       install: make install
       name: lint


### PR DESCRIPTION
We are in the process of standardizing how to manage the dockerhub key, remove build/push for now.