### PR TITLE
Fix filtering for queries with multiple partitions

### DIFF
--- a/pkg/manager/impl/artifact_manager_test.go
+++ b/pkg/manager/impl/artifact_manager_test.go
@@ -532,15 +532,13 @@ func TestListArtifact(t *testing.T) {
 					dataset.Version == expectedDataset.Id.Version
 			}),
 			mock.MatchedBy(func(listInput models.ListModelsInput) bool {
-				return len(listInput.Filters) == 5 &&
-					len(listInput.JoinEntityToConditionMap) == 2 &&
-					listInput.Filters[0].GetDBEntity() == common.Partition &&
-					listInput.Filters[1].GetDBEntity() == common.Partition &&
-					listInput.Filters[2].GetDBEntity() == common.Partition &&
-					listInput.Filters[3].GetDBEntity() == common.Partition &&
-					listInput.Filters[4].GetDBEntity() == common.Tag &&
-					listInput.JoinEntityToConditionMap[common.Partition] != nil &&
-					listInput.JoinEntityToConditionMap[common.Tag] != nil &&
+				return len(listInput.ModelFilters) == 3 &&
+					listInput.ModelFilters[0].Entity == common.Partition &&
+					len(listInput.ModelFilters[0].ValueFilters) == 2 &&
+					listInput.ModelFilters[1].Entity == common.Partition &&
+					len(listInput.ModelFilters[1].ValueFilters) == 2 &&
+					listInput.ModelFilters[2].Entity == common.Tag &&
+					len(listInput.ModelFilters[2].ValueFilters) == 1 &&
 					listInput.Limit == 50 &&
 					listInput.Offset == 0
 			})).Return(mockArtifacts, nil)
@@ -574,8 +572,7 @@ func TestListArtifact(t *testing.T) {
 					dataset.Version == expectedDataset.Id.Version
 			}),
 			mock.MatchedBy(func(listInput models.ListModelsInput) bool {
-				return len(listInput.Filters) == 0 &&
-					len(listInput.JoinEntityToConditionMap) == 0
+				return len(listInput.ModelFilters) == 0
 			})).Return(mockArtifacts, nil)
 
 		artifactResponse, err := artifactManager.ListArtifacts(ctx, datacatalog.ListArtifactsRequest{Dataset: expectedDataset.Id, Filter: filter})

--- a/pkg/repositories/gormimpl/artifact.go
+++ b/pkg/repositories/gormimpl/artifact.go
@@ -85,7 +85,7 @@ func (h *artifactRepo) List(ctx context.Context, datasetKey models.DatasetKey, i
 	// add filter for dataset
 	datasetUUIDFilter := NewGormValueFilter(sourceEntity, common.Equal, "dataset_uuid", datasetKey.UUID)
 	datasetFilter := models.ModelFilter{
-		Entity: common.Artifact,
+		Entity:       common.Artifact,
 		ValueFilters: []models.ModelValueFilter{datasetUUIDFilter},
 	}
 	in.ModelFilters = append(in.ModelFilters, datasetFilter)

--- a/pkg/repositories/gormimpl/artifact.go
+++ b/pkg/repositories/gormimpl/artifact.go
@@ -83,7 +83,7 @@ func (h *artifactRepo) List(ctx context.Context, datasetKey models.DatasetKey, i
 	sourceEntity := common.Artifact
 
 	// add filter for dataset
-	datasetUUIDFilter := NewGormValueFilter(sourceEntity, common.Equal, "dataset_uuid", datasetKey.UUID)
+	datasetUUIDFilter := NewGormValueFilter(common.Equal, "dataset_uuid", datasetKey.UUID)
 	datasetFilter := models.ModelFilter{
 		Entity:       common.Artifact,
 		ValueFilters: []models.ModelValueFilter{datasetUUIDFilter},

--- a/pkg/repositories/gormimpl/artifact.go
+++ b/pkg/repositories/gormimpl/artifact.go
@@ -84,7 +84,11 @@ func (h *artifactRepo) List(ctx context.Context, datasetKey models.DatasetKey, i
 
 	// add filter for dataset
 	datasetUUIDFilter := NewGormValueFilter(sourceEntity, common.Equal, "dataset_uuid", datasetKey.UUID)
-	in.Filters = append(in.Filters, datasetUUIDFilter)
+	datasetFilter := models.ModelFilter{
+		Entity: common.Artifact,
+		ValueFilters: []models.ModelValueFilter{datasetUUIDFilter},
+	}
+	in.ModelFilters = append(in.ModelFilters, datasetFilter)
 
 	// apply filters and joins
 	tx, err := applyListModelsInput(h.db, sourceEntity, in)

--- a/pkg/repositories/gormimpl/artifact_test.go
+++ b/pkg/repositories/gormimpl/artifact_test.go
@@ -240,7 +240,7 @@ func TestListArtifactsWithPartition(t *testing.T) {
 	expectedPartitionResponse := getDBPartitionResponse(artifact)
 
 	GlobalMock.NewMock().WithQuery(
-		`SELECT "artifacts".* FROM "artifacts" JOIN partitions ON artifacts.artifact_id = partitions.artifact_id WHERE "artifacts"."deleted_at" IS NULL AND ((partitions.key1 = val1) AND (partitions.key2 = val2) AND (artifacts.dataset_uuid = test-uuid)) ORDER BY artifacts.created_at desc LIMIT 10 OFFSET 10`).WithReply(expectedArtifactResponse)
+		`SELECT "artifacts".* FROM "artifacts" JOIN partitions partitions0 ON artifacts.artifact_id = partitions0.artifact_id WHERE "artifacts"."deleted_at" IS NULL AND ((partitions0.key = val1) AND (partitions0.val = val2) AND (artifacts.dataset_uuid = test-uuid)) ORDER BY artifacts.created_at desc LIMIT 10 OFFSET 10`).WithReply(expectedArtifactResponse)
 	GlobalMock.NewMock().WithQuery(
 		`SELECT * FROM "artifact_data"  WHERE "artifact_data"."deleted_at" IS NULL AND ((("dataset_project","dataset_name","dataset_domain","dataset_version","artifact_id") IN ((testProject,testName,testDomain,testVersion,123))))`).WithReply(expectedArtifactDataResponse)
 	GlobalMock.NewMock().WithQuery(
@@ -252,8 +252,8 @@ func TestListArtifactsWithPartition(t *testing.T) {
 			{Entity: common.Partition,
 			 JoinCondition: NewGormJoinCondition(common.Artifact, common.Partition),
 			 ValueFilters: []models.ModelValueFilter{
-					NewGormValueFilter(common.Partition, common.Equal, "key1", "val1"),
-					NewGormValueFilter(common.Partition, common.Equal, "key2", "val2"),
+					NewGormValueFilter(common.Partition, common.Equal, "key", "val1"),
+					NewGormValueFilter(common.Partition, common.Equal, "val", "val2"),
 				},
 			},
 		},

--- a/pkg/repositories/gormimpl/artifact_test.go
+++ b/pkg/repositories/gormimpl/artifact_test.go
@@ -250,8 +250,8 @@ func TestListArtifactsWithPartition(t *testing.T) {
 	listInput := models.ListModelsInput{
 		ModelFilters: []models.ModelFilter{
 			{Entity: common.Partition,
-			 JoinCondition: NewGormJoinCondition(common.Artifact, common.Partition),
-			 ValueFilters: []models.ModelValueFilter{
+				JoinCondition: NewGormJoinCondition(common.Artifact, common.Partition),
+				ValueFilters: []models.ModelValueFilter{
 					NewGormValueFilter(common.Equal, "key", "val1"),
 					NewGormValueFilter(common.Equal, "val", "val2"),
 				},

--- a/pkg/repositories/gormimpl/artifact_test.go
+++ b/pkg/repositories/gormimpl/artifact_test.go
@@ -248,12 +248,14 @@ func TestListArtifactsWithPartition(t *testing.T) {
 
 	artifactRepo := NewArtifactRepo(utils.GetDbForTest(t), errors.NewPostgresErrorTransformer(), promutils.NewTestScope())
 	listInput := models.ListModelsInput{
-		JoinEntityToConditionMap: map[common.Entity]models.ModelJoinCondition{
-			common.Partition: NewGormJoinCondition(common.Artifact, common.Partition),
-		},
-		Filters: []models.ModelValueFilter{
-			NewGormValueFilter(common.Partition, common.Equal, "key1", "val1"),
-			NewGormValueFilter(common.Partition, common.Equal, "key2", "val2"),
+		ModelFilters: []models.ModelFilter{
+			{Entity: common.Partition,
+			 JoinCondition: NewGormJoinCondition(common.Artifact, common.Partition),
+			 ValueFilters: []models.ModelValueFilter{
+					NewGormValueFilter(common.Partition, common.Equal, "key1", "val1"),
+					NewGormValueFilter(common.Partition, common.Equal, "key2", "val2"),
+				},
+			},
 		},
 		Offset:        10,
 		Limit:         10,

--- a/pkg/repositories/gormimpl/artifact_test.go
+++ b/pkg/repositories/gormimpl/artifact_test.go
@@ -252,8 +252,8 @@ func TestListArtifactsWithPartition(t *testing.T) {
 			{Entity: common.Partition,
 			 JoinCondition: NewGormJoinCondition(common.Artifact, common.Partition),
 			 ValueFilters: []models.ModelValueFilter{
-					NewGormValueFilter(common.Partition, common.Equal, "key", "val1"),
-					NewGormValueFilter(common.Partition, common.Equal, "val", "val2"),
+					NewGormValueFilter(common.Equal, "key", "val1"),
+					NewGormValueFilter(common.Equal, "val", "val2"),
 				},
 			},
 		},

--- a/pkg/repositories/gormimpl/filter.go
+++ b/pkg/repositories/gormimpl/filter.go
@@ -14,15 +14,9 @@ const (
 )
 
 type gormValueFilterImpl struct {
-	entity             common.Entity // TODO: can remove this since we have it in ModelFilter
 	comparisonOperator common.ComparisonOperator
 	field              string
 	value              interface{}
-}
-
-// TODO: can remove this since we have it in ModelFilter
-func (g *gormValueFilterImpl) GetDBEntity() common.Entity {
-	return g.entity
 }
 
 // Get the GORM expression to filter by a model's property. The output should be a valid input into tx.Where()
@@ -38,9 +32,8 @@ func (g *gormValueFilterImpl) GetDBQueryExpression(tableName string) (models.DBQ
 }
 
 // Construct the container necessary to issue a db query to filter in GORM
-func NewGormValueFilter(entity common.Entity, comparisonOperator common.ComparisonOperator, field string, value interface{}) models.ModelValueFilter {
+func NewGormValueFilter(comparisonOperator common.ComparisonOperator, field string, value interface{}) models.ModelValueFilter {
 	return &gormValueFilterImpl{
-		entity:             entity, // TODO: can remove this since we have it in ModelFilter
 		comparisonOperator: comparisonOperator,
 		field:              field,
 		value:              value,

--- a/pkg/repositories/gormimpl/filter.go
+++ b/pkg/repositories/gormimpl/filter.go
@@ -14,12 +14,13 @@ const (
 )
 
 type gormValueFilterImpl struct {
-	entity             common.Entity
+	entity             common.Entity // TODO: can remove this since we have it in ModelFilter
 	comparisonOperator common.ComparisonOperator
 	field              string
 	value              interface{}
 }
 
+// TODO: can remove this since we have it in ModelFilter
 func (g *gormValueFilterImpl) GetDBEntity() common.Entity {
 	return g.entity
 }
@@ -39,7 +40,7 @@ func (g *gormValueFilterImpl) GetDBQueryExpression(tableName string) (models.DBQ
 // Construct the container necessary to issue a db query to filter in GORM
 func NewGormValueFilter(entity common.Entity, comparisonOperator common.ComparisonOperator, field string, value interface{}) models.ModelValueFilter {
 	return &gormValueFilterImpl{
-		entity:             entity,
+		entity:             entity, // TODO: can remove this since we have it in ModelFilter
 		comparisonOperator: comparisonOperator,
 		field:              field,
 		value:              value,

--- a/pkg/repositories/gormimpl/filter_test.go
+++ b/pkg/repositories/gormimpl/filter_test.go
@@ -11,7 +11,6 @@ func TestGormValueFilter(t *testing.T) {
 	filter := NewGormValueFilter(common.Partition, common.Equal, "key", "region")
 	expression, err := filter.GetDBQueryExpression("partitions")
 	assert.NoError(t, err)
-	assert.Equal(t, filter.GetDBEntity(), common.Partition)
 	assert.Equal(t, expression.Query, "partitions.key = ?")
 	assert.Equal(t, expression.Args, "region")
 }

--- a/pkg/repositories/gormimpl/filter_test.go
+++ b/pkg/repositories/gormimpl/filter_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGormValueFilter(t *testing.T) {
-	filter := NewGormValueFilter(common.Partition, common.Equal, "key", "region")
+	filter := NewGormValueFilter(common.Equal, "key", "region")
 	expression, err := filter.GetDBQueryExpression("partitions")
 	assert.NoError(t, err)
 	assert.Equal(t, expression.Query, "partitions.key = ?")
@@ -16,7 +16,7 @@ func TestGormValueFilter(t *testing.T) {
 }
 
 func TestGormValueFilterInvalidOperator(t *testing.T) {
-	filter := NewGormValueFilter(common.Partition, 123, "key", "region")
+	filter := NewGormValueFilter(123, "key", "region")
 	_, err := filter.GetDBQueryExpression("partitions")
 	assert.Error(t, err)
 }

--- a/pkg/repositories/gormimpl/join.go
+++ b/pkg/repositories/gormimpl/join.go
@@ -12,7 +12,7 @@ import (
 const (
 	joinCondition = "JOIN %s %s ON %s" // Format for the join: JOIN <table name> <table alias> ON <columns to join>
 	joinEquals    = "%s.%s = %s.%s"    // Format for the columns to join: <tableAlias>.<column> = <tableAlias>.<column>
-	joinSeparator = " AND "            // Seperator if there's more than one joining column
+	joinSeparator = " AND "            // Separator if there's more than one joining column
 )
 
 // JoinOnMap is a map of the properties for joining source table to joining table

--- a/pkg/repositories/gormimpl/join.go
+++ b/pkg/repositories/gormimpl/join.go
@@ -1,8 +1,9 @@
 package gormimpl
 
 import (
-	"strings"
 	"fmt"
+	"strings"
+
 	"github.com/lyft/datacatalog/pkg/common"
 	"github.com/lyft/datacatalog/pkg/repositories/errors"
 	"github.com/lyft/datacatalog/pkg/repositories/models"

--- a/pkg/repositories/gormimpl/join.go
+++ b/pkg/repositories/gormimpl/join.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	joinCondition = "JOIN %s %s ON %s"
-	joinEquals    = "%s.%s = %s.%s"
-	joinSeparator = " AND "
+	joinCondition = "JOIN %s %s ON %s" // Format for the join: JOIN <table name> <table alias> ON <columns to join>
+	joinEquals    = "%s.%s = %s.%s"    // Format for the columns to join: <tableAlias>.<column> = <tableAlias>.<column>
+	joinSeparator = " AND "            // Seperator if there's more than one joining column
 )
 
 // JoinOnMap is a map of the properties for joining source table to joining table

--- a/pkg/repositories/gormimpl/join.go
+++ b/pkg/repositories/gormimpl/join.go
@@ -1,16 +1,15 @@
 package gormimpl
 
 import (
-	"fmt"
 	"strings"
-
+	"fmt"
 	"github.com/lyft/datacatalog/pkg/common"
 	"github.com/lyft/datacatalog/pkg/repositories/errors"
 	"github.com/lyft/datacatalog/pkg/repositories/models"
 )
 
 const (
-	joinCondition = "JOIN %s ON %s"
+	joinCondition = "JOIN %s %s ON %s"
 	joinEquals    = "%s.%s = %s.%s"
 	joinSeparator = " AND "
 )
@@ -36,7 +35,7 @@ type gormJoinConditionImpl struct {
 }
 
 // Get the GORM expression to JOIN two entities. The output should be a valid input into tx.Join()
-func (g *gormJoinConditionImpl) GetJoinOnDBQueryExpression(sourceTableName string, joiningTableName string) (string, error) {
+func (g *gormJoinConditionImpl) GetJoinOnDBQueryExpression(sourceTableName string, joiningTableName string, joiningTableAlias string) (string, error) {
 	joinOnFieldMap, err := g.getJoinOnFields()
 
 	if err != nil {
@@ -45,11 +44,11 @@ func (g *gormJoinConditionImpl) GetJoinOnDBQueryExpression(sourceTableName strin
 
 	joinFields := make([]string, 0, len(joinOnFieldMap))
 	for sourceField, joiningField := range joinOnFieldMap {
-		joinFieldCondition := fmt.Sprintf(joinEquals, sourceTableName, sourceField, joiningTableName, joiningField)
+		joinFieldCondition := fmt.Sprintf(joinEquals, sourceTableName, sourceField, joiningTableAlias, joiningField)
 		joinFields = append(joinFields, joinFieldCondition)
 	}
 
-	return fmt.Sprintf(joinCondition, joiningTableName, strings.Join(joinFields, joinSeparator)), nil
+	return fmt.Sprintf(joinCondition, joiningTableName, joiningTableAlias, strings.Join(joinFields, joinSeparator)), nil
 }
 
 // Get the properties necessary to join two GORM models

--- a/pkg/repositories/gormimpl/join_test.go
+++ b/pkg/repositories/gormimpl/join_test.go
@@ -9,15 +9,15 @@ import (
 
 func TestGormJoinCondition(t *testing.T) {
 	filter := NewGormJoinCondition(common.Artifact, common.Partition)
-	joinQuery, err := filter.GetJoinOnDBQueryExpression("artifacts", "partitions")
+	joinQuery, err := filter.GetJoinOnDBQueryExpression("artifacts", "partitions", "p")
 	assert.NoError(t, err)
-	assert.Equal(t, joinQuery, "JOIN partitions ON artifacts.artifact_id = partitions.artifact_id")
+	assert.Equal(t, joinQuery, "JOIN partitions p ON artifacts.artifact_id = p.artifact_id")
 }
 
 // Tag cannot be joined with partitions
 func TestInvalidGormJoinCondition(t *testing.T) {
 	filter := NewGormJoinCondition(common.Tag, common.Partition)
 
-	_, err := filter.GetJoinOnDBQueryExpression("tags", "partitions")
+	_, err := filter.GetJoinOnDBQueryExpression("tags", "partitions", "t")
 	assert.Error(t, err)
 }

--- a/pkg/repositories/gormimpl/list.go
+++ b/pkg/repositories/gormimpl/list.go
@@ -2,6 +2,7 @@ package gormimpl
 
 import (
 	"fmt"
+
 	"github.com/jinzhu/gorm"
 	"github.com/lyft/datacatalog/pkg/common"
 	"github.com/lyft/datacatalog/pkg/repositories/errors"

--- a/pkg/repositories/gormimpl/list.go
+++ b/pkg/repositories/gormimpl/list.go
@@ -1,10 +1,15 @@
 package gormimpl
 
 import (
+	"fmt"
 	"github.com/jinzhu/gorm"
 	"github.com/lyft/datacatalog/pkg/common"
 	"github.com/lyft/datacatalog/pkg/repositories/errors"
 	"github.com/lyft/datacatalog/pkg/repositories/models"
+)
+
+const (
+	tableAliasFormat = "%s%d"
 )
 
 var entityToModel = map[common.Entity]interface{}{
@@ -19,39 +24,39 @@ var entityToModel = map[common.Entity]interface{}{
 func applyListModelsInput(tx *gorm.DB, sourceEntity common.Entity, in models.ListModelsInput) (*gorm.DB, error) {
 	sourceModel, ok := entityToModel[sourceEntity]
 	if !ok {
+		print("here")
 		return nil, errors.GetInvalidEntityError(sourceEntity)
 	}
 
 	sourceTableName := tx.NewScope(sourceModel).TableName()
-	for joiningEntity, joinCondition := range in.JoinEntityToConditionMap {
-		joiningModel, ok := entityToModel[joiningEntity]
+	for modelIndex, modelFilter := range in.ModelFilters {
+		entity := modelFilter.Entity
+		filterModel, ok := entityToModel[entity]
 		if !ok {
-			return nil, errors.GetInvalidEntityError(joiningEntity)
+			return nil, errors.GetInvalidEntityError(entity)
+		}
+		tableName := tx.NewScope(filterModel).TableName()
+		tableAlias := tableName
+
+		// Optionally add the join condition if this filter has one
+		if joinCondition := modelFilter.JoinCondition; joinCondition != nil {
+			// if there is a join associated with the filter, we should use an alias
+			tableAlias = fmt.Sprintf(tableAliasFormat, tableName, modelIndex)
+			joinExpression, err := joinCondition.GetJoinOnDBQueryExpression(sourceTableName, tableName, tableAlias)
+			if err != nil {
+				return nil, err
+			}
+			tx = tx.Joins(joinExpression)
 		}
 
-		joiningTableName := tx.NewScope(joiningModel).TableName()
-		joinExpression, err := joinCondition.GetJoinOnDBQueryExpression(sourceTableName, joiningTableName)
-		if err != nil {
-			return nil, err
+		for _, whereFilter := range modelFilter.ValueFilters {
+			dbQueryExpr, err := whereFilter.GetDBQueryExpression(tableAlias)
+
+			if err != nil {
+				return nil, err
+			}
+			tx = tx.Where(dbQueryExpr.Query, dbQueryExpr.Args)
 		}
-		tx = tx.Joins(joinExpression)
-	}
-
-	for _, whereFilter := range in.Filters {
-		filterEntity := whereFilter.GetDBEntity()
-		filterModel, ok := entityToModel[filterEntity]
-		if !ok {
-			return nil, errors.GetInvalidEntityError(filterEntity)
-		}
-
-		entityTableName := tx.NewScope(filterModel).TableName()
-
-		dbQueryExpr, err := whereFilter.GetDBQueryExpression(entityTableName)
-
-		if err != nil {
-			return nil, err
-		}
-		tx = tx.Where(dbQueryExpr.Query, dbQueryExpr.Args)
 	}
 
 	tx = tx.Limit(in.Limit)

--- a/pkg/repositories/gormimpl/list.go
+++ b/pkg/repositories/gormimpl/list.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	tableAliasFormat = "%s%d"
+	tableAliasFormat = "%s%d" // Table Alias is the "<table name><index>"
 )
 
 var entityToModel = map[common.Entity]interface{}{
@@ -24,7 +24,6 @@ var entityToModel = map[common.Entity]interface{}{
 func applyListModelsInput(tx *gorm.DB, sourceEntity common.Entity, in models.ListModelsInput) (*gorm.DB, error) {
 	sourceModel, ok := entityToModel[sourceEntity]
 	if !ok {
-		print("here")
 		return nil, errors.GetInvalidEntityError(sourceEntity)
 	}
 

--- a/pkg/repositories/gormimpl/list_test.go
+++ b/pkg/repositories/gormimpl/list_test.go
@@ -23,22 +23,30 @@ func TestApplyFilter(t *testing.T) {
 		`SELECT "artifacts".* FROM "artifacts"`).WithCallback(
 		func(s string, values []driver.NamedValue) {
 			// separate the regex matching because the joins reorder on different test runs
-			validInputApply = strings.Contains(s, `JOIN tags ON artifacts.artifact_id = tags.artifact_id`) &&
-				strings.Contains(s, `JOIN partitions ON artifacts.artifact_id = partitions.artifact_id`) &&
+			validInputApply = strings.Contains(s, `JOIN tags tags1 ON artifacts.artifact_id = tags1.artifact_id`) &&
+				strings.Contains(s, `JOIN partitions partitions0 ON artifacts.artifact_id = partitions0.artifact_id`) &&
 				strings.Contains(s, `WHERE "artifacts"."deleted_at" IS NULL AND `+
-					`((partitions.key1 = val1) AND (partitions.key2 = val2) AND (tags.tag_name = special)) `+
+					`((partitions0.key1 = val1) AND (partitions0.key2 = val2) AND (tags1.tag_name = special)) `+
 					`ORDER BY artifacts.created_at desc LIMIT 10 OFFSET 10`)
 		})
 
 	listInput := models.ListModelsInput{
-		JoinEntityToConditionMap: map[common.Entity]models.ModelJoinCondition{
-			common.Partition: NewGormJoinCondition(common.Artifact, common.Partition),
-			common.Tag:       NewGormJoinCondition(common.Artifact, common.Tag),
-		},
-		Filters: []models.ModelValueFilter{
-			NewGormValueFilter(common.Partition, common.Equal, "key1", "val1"),
-			NewGormValueFilter(common.Partition, common.Equal, "key2", "val2"),
-			NewGormValueFilter(common.Tag, common.Equal, "tag_name", "special"),
+		ModelFilters: []models.ModelFilter{
+			{
+				Entity:        common.Partition,
+				JoinCondition: NewGormJoinCondition(common.Artifact, common.Partition),
+				ValueFilters: []models.ModelValueFilter{
+					NewGormValueFilter(common.Partition, common.Equal, "key1", "val1"),
+					NewGormValueFilter(common.Partition, common.Equal, "key2", "val2"),
+				},
+			},
+			{
+				Entity: common.Tag,
+				JoinCondition: NewGormJoinCondition(common.Artifact, common.Tag),
+				ValueFilters: []models.ModelValueFilter{
+					NewGormValueFilter(common.Tag, common.Equal, "tag_name", "special"),
+				},
+			},
 		},
 		Offset:        10,
 		Limit:         10,
@@ -66,8 +74,6 @@ func TestApplyFilterEmpty(t *testing.T) {
 		})
 
 	listInput := models.ListModelsInput{
-		JoinEntityToConditionMap: nil,
-		Filters:                  nil,
 		Offset:                   10,
 		Limit:                    10,
 	}

--- a/pkg/repositories/gormimpl/list_test.go
+++ b/pkg/repositories/gormimpl/list_test.go
@@ -36,15 +36,15 @@ func TestApplyFilter(t *testing.T) {
 				Entity:        common.Partition,
 				JoinCondition: NewGormJoinCondition(common.Artifact, common.Partition),
 				ValueFilters: []models.ModelValueFilter{
-					NewGormValueFilter(common.Partition, common.Equal, "key1", "val1"),
-					NewGormValueFilter(common.Partition, common.Equal, "key2", "val2"),
+					NewGormValueFilter(common.Equal, "key1", "val1"),
+					NewGormValueFilter(common.Equal, "key2", "val2"),
 				},
 			},
 			{
 				Entity: common.Tag,
 				JoinCondition: NewGormJoinCondition(common.Artifact, common.Tag),
 				ValueFilters: []models.ModelValueFilter{
-					NewGormValueFilter(common.Tag, common.Equal, "tag_name", "special"),
+					NewGormValueFilter(common.Equal, "tag_name", "special"),
 				},
 			},
 		},

--- a/pkg/repositories/gormimpl/list_test.go
+++ b/pkg/repositories/gormimpl/list_test.go
@@ -41,7 +41,7 @@ func TestApplyFilter(t *testing.T) {
 				},
 			},
 			{
-				Entity: common.Tag,
+				Entity:        common.Tag,
 				JoinCondition: NewGormJoinCondition(common.Artifact, common.Tag),
 				ValueFilters: []models.ModelValueFilter{
 					NewGormValueFilter(common.Equal, "tag_name", "special"),
@@ -74,8 +74,8 @@ func TestApplyFilterEmpty(t *testing.T) {
 		})
 
 	listInput := models.ListModelsInput{
-		Offset:                   10,
-		Limit:                    10,
+		Offset: 10,
+		Limit:  10,
 	}
 
 	tx, err := applyListModelsInput(testDB, common.Artifact, listInput)

--- a/pkg/repositories/models/list.go
+++ b/pkg/repositories/models/list.go
@@ -31,9 +31,9 @@ type ModelJoinCondition interface {
 // A single filter for a model encompasses value filters and optionally a join condition if the filter is not on
 // the source model
 type ModelFilter struct {
-	ValueFilters []ModelValueFilter
+	ValueFilters  []ModelValueFilter
 	JoinCondition ModelJoinCondition
-	Entity common.Entity
+	Entity        common.Entity
 }
 
 // Encapsulates the query and necessary arguments to issue a DB query.

--- a/pkg/repositories/models/list.go
+++ b/pkg/repositories/models/list.go
@@ -4,10 +4,8 @@ import "github.com/lyft/datacatalog/pkg/common"
 
 // Inputs to specify to list models
 type ListModelsInput struct {
-	// JoinEntityToConditionMap for the list query. It is represented as a 1:1 mapping between a joiningEntity and a joinCondition
-	JoinEntityToConditionMap map[common.Entity]ModelJoinCondition
-	// Value filters for the list query
-	Filters []ModelValueFilter
+	// The filters for the list
+	ModelFilters []ModelFilter
 	// The number of models to list
 	Limit uint32
 	// The token to offset results by
@@ -22,12 +20,20 @@ type SortParameter interface {
 
 // Generates db filter expressions for model values
 type ModelValueFilter interface {
-	GetDBEntity() common.Entity
 	GetDBQueryExpression(tableName string) (DBQueryExpr, error)
 }
 
+// Generates the join expressions for filters that require other entities
 type ModelJoinCondition interface {
-	GetJoinOnDBQueryExpression(sourceTableName string, joiningTableName string) (string, error)
+	GetJoinOnDBQueryExpression(sourceTableName string, joiningTableName string, joiningTableAlias string) (string, error)
+}
+
+// A single filter for a model encompasses value filters and optionally a join condition if the filter is not on
+// the source model
+type ModelFilter struct {
+	ValueFilters []ModelValueFilter
+	JoinCondition ModelJoinCondition
+	Entity common.Entity
 }
 
 // Encapsulates the query and necessary arguments to issue a DB query.

--- a/pkg/repositories/transformers/filters.go
+++ b/pkg/repositories/transformers/filters.go
@@ -23,38 +23,24 @@ var comparisonOperatorMap = map[datacatalog.SinglePropertyFilter_ComparisonOpera
 }
 
 func FilterToListInput(ctx context.Context, sourceEntity common.Entity, filterExpression *datacatalog.FilterExpression) (models.ListModelsInput, error) {
-	// ListInput is composed of ModelFilters and ModelJoins. Let's construct those filters and joins.
-	modelFilters := make([]models.ModelValueFilter, 0, len(filterExpression.GetFilters()))
-	joinModelMap := make(map[common.Entity]models.ModelJoinCondition)
+	// ListInput is composed of filters and joins for multiple entities, lets construct that
+	modelFilters := make([]models.ModelFilter, 0, len(filterExpression.GetFilters()))
 
-	// First construct the model filters
+	// Construct the ModelFilter for each PropertyFilter
 	for _, filter := range filterExpression.GetFilters() {
-		modelPropertyFilters, err := constructModelValueFilters(ctx, filter)
+		modelFilter, err := constructModelFilter(ctx, filter, sourceEntity)
 		if err != nil {
 			return models.ListModelsInput{}, err
 		}
-
-		modelFilters = append(modelFilters, modelPropertyFilters...)
+		modelFilters = append(modelFilters, modelFilter)
 	}
 
-	// Then add necessary joins if there are filters that are not the source entity
-	for _, modelFilter := range modelFilters {
-		joinEntity := modelFilter.GetDBEntity()
-		if _, exists := joinModelMap[joinEntity]; !exists && sourceEntity != joinEntity {
-			joinModelMap[joinEntity] = gormimpl.NewGormJoinCondition(sourceEntity, joinEntity)
-		}
-
-	}
-
-	// Need to add limit/offset/Sort
 	return models.ListModelsInput{
-		Filters:                  modelFilters,
-		JoinEntityToConditionMap: joinModelMap,
+		ModelFilters: modelFilters,
 	}, nil
 }
 
-func constructModelValueFilters(ctx context.Context, singleFilter *datacatalog.SinglePropertyFilter) ([]models.ModelValueFilter, error) {
-	modelValueFilters := make([]models.ModelValueFilter, 0, 1)
+func constructModelFilter(ctx context.Context, singleFilter *datacatalog.SinglePropertyFilter, sourceEntity common.Entity) (models.ModelFilter, error) {
 	operator := comparisonOperatorMap[singleFilter.Operator]
 
 	switch propertyFilter := singleFilter.GetPropertyFilter().(type) {
@@ -68,14 +54,20 @@ func constructModelValueFilters(ctx context.Context, singleFilter *datacatalog.S
 
 			logger.Debugf(ctx, "Constructing partition key:[%v], val:[%v] filter", key, value)
 			if err := validators.ValidateEmptyStringField(key, "PartitionKey"); err != nil {
-				return nil, err
+				return models.ModelFilter{}, err
 			}
 			if err := validators.ValidateEmptyStringField(value, "PartitionValue"); err != nil {
-				return nil, err
+				return models.ModelFilter{}, err
 			}
 			partitionKeyFilter := gormimpl.NewGormValueFilter(common.Partition, operator, partitionKeyFieldName, key)
 			partitionValueFilter := gormimpl.NewGormValueFilter(common.Partition, operator, partitionValueFieldName, value)
-			modelValueFilters = append(modelValueFilters, partitionKeyFilter, partitionValueFilter)
+			modelValueFilters := []models.ModelValueFilter{partitionKeyFilter, partitionValueFilter}
+
+			return models.ModelFilter{
+				Entity: common.Partition,
+				ValueFilters: modelValueFilters,
+				JoinCondition: gormimpl.NewGormJoinCondition(sourceEntity, common.Partition),
+			}, nil
 		}
 	case *datacatalog.SinglePropertyFilter_TagFilter:
 		switch tagProperty := propertyFilter.TagFilter.GetProperty().(type) {
@@ -83,11 +75,17 @@ func constructModelValueFilters(ctx context.Context, singleFilter *datacatalog.S
 			tagName := tagProperty.TagName
 			logger.Debugf(ctx, "Constructing Tag filter name:[%v]", tagName)
 			if err := validators.ValidateEmptyStringField(tagProperty.TagName, "TagName"); err != nil {
-				return nil, err
+				return models.ModelFilter{}, err
 			}
 			tagNameFilter := gormimpl.NewGormValueFilter(common.Tag, operator, tagNameFieldName, tagName)
-			modelValueFilters = append(modelValueFilters, tagNameFilter)
+			modelValueFilters := []models.ModelValueFilter{tagNameFilter}
+
+			return models.ModelFilter{
+				Entity: common.Tag,
+				ValueFilters: modelValueFilters,
+				JoinCondition: gormimpl.NewGormJoinCondition(sourceEntity, common.Tag),
+			}, nil
 		}
 	}
-	return modelValueFilters, nil
+	return models.ModelFilter{}, nil
 }

--- a/pkg/repositories/transformers/filters.go
+++ b/pkg/repositories/transformers/filters.go
@@ -59,8 +59,8 @@ func constructModelFilter(ctx context.Context, singleFilter *datacatalog.SingleP
 			if err := validators.ValidateEmptyStringField(value, "PartitionValue"); err != nil {
 				return models.ModelFilter{}, err
 			}
-			partitionKeyFilter := gormimpl.NewGormValueFilter(common.Partition, operator, partitionKeyFieldName, key)
-			partitionValueFilter := gormimpl.NewGormValueFilter(common.Partition, operator, partitionValueFieldName, value)
+			partitionKeyFilter := gormimpl.NewGormValueFilter(operator, partitionKeyFieldName, key)
+			partitionValueFilter := gormimpl.NewGormValueFilter(operator, partitionValueFieldName, value)
 			modelValueFilters := []models.ModelValueFilter{partitionKeyFilter, partitionValueFilter}
 
 			return models.ModelFilter{
@@ -77,7 +77,7 @@ func constructModelFilter(ctx context.Context, singleFilter *datacatalog.SingleP
 			if err := validators.ValidateEmptyStringField(tagProperty.TagName, "TagName"); err != nil {
 				return models.ModelFilter{}, err
 			}
-			tagNameFilter := gormimpl.NewGormValueFilter(common.Tag, operator, tagNameFieldName, tagName)
+			tagNameFilter := gormimpl.NewGormValueFilter(operator, tagNameFieldName, tagName)
 			modelValueFilters := []models.ModelValueFilter{tagNameFilter}
 
 			return models.ModelFilter{

--- a/pkg/repositories/transformers/filters.go
+++ b/pkg/repositories/transformers/filters.go
@@ -64,8 +64,8 @@ func constructModelFilter(ctx context.Context, singleFilter *datacatalog.SingleP
 			modelValueFilters := []models.ModelValueFilter{partitionKeyFilter, partitionValueFilter}
 
 			return models.ModelFilter{
-				Entity: common.Partition,
-				ValueFilters: modelValueFilters,
+				Entity:        common.Partition,
+				ValueFilters:  modelValueFilters,
 				JoinCondition: gormimpl.NewGormJoinCondition(sourceEntity, common.Partition),
 			}, nil
 		}
@@ -81,8 +81,8 @@ func constructModelFilter(ctx context.Context, singleFilter *datacatalog.SingleP
 			modelValueFilters := []models.ModelValueFilter{tagNameFilter}
 
 			return models.ModelFilter{
-				Entity: common.Tag,
-				ValueFilters: modelValueFilters,
+				Entity:        common.Tag,
+				ValueFilters:  modelValueFilters,
 				JoinCondition: gormimpl.NewGormJoinCondition(sourceEntity, common.Tag),
 			}, nil
 		}

--- a/pkg/repositories/transformers/filters_test.go
+++ b/pkg/repositories/transformers/filters_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/lyft/datacatalog/pkg/common"
-	"github.com/lyft/datacatalog/protos/gen"
-	"github.com/stretchr/testify/assert"
 	"github.com/lyft/datacatalog/pkg/repositories/models"
+	datacatalog "github.com/lyft/datacatalog/protos/gen"
+	"github.com/stretchr/testify/assert"
 )
 
 func assertJoinExpression(t *testing.T, joinCondition models.ModelJoinCondition, sourceTableName string, joiningTableName string, joiningTableAlias string, expectedJoinStatement string) {
@@ -61,23 +61,23 @@ func TestListInputWithPartitionsAndTags(t *testing.T) {
 	// Should have 3 filters: 2 for partitions, 1 for tag
 	assert.Len(t, listInput.ModelFilters, 3)
 
-	assertFilterExpression(t, listInput.ModelFilters[0].ValueFilters[0],"partitions",
+	assertFilterExpression(t, listInput.ModelFilters[0].ValueFilters[0], "partitions",
 		"partitions.key = ?", "key1")
-	assertFilterExpression(t, listInput.ModelFilters[0].ValueFilters[1],"partitions",
+	assertFilterExpression(t, listInput.ModelFilters[0].ValueFilters[1], "partitions",
 		"partitions.value = ?", "val1")
-	assertJoinExpression(t,listInput.ModelFilters[0].JoinCondition, "artifacts", "partitions",
+	assertJoinExpression(t, listInput.ModelFilters[0].JoinCondition, "artifacts", "partitions",
 		"p1", "JOIN partitions p1 ON artifacts.artifact_id = p1.artifact_id")
 
 	assertFilterExpression(t, listInput.ModelFilters[1].ValueFilters[0], "partitions",
 		"partitions.key = ?", "key2")
 	assertFilterExpression(t, listInput.ModelFilters[1].ValueFilters[1], "partitions",
 		"partitions.value = ?", "val2")
-	assertJoinExpression(t,listInput.ModelFilters[1].JoinCondition, "artifacts", "partitions",
+	assertJoinExpression(t, listInput.ModelFilters[1].JoinCondition, "artifacts", "partitions",
 		"p2", "JOIN partitions p2 ON artifacts.artifact_id = p2.artifact_id")
 
 	assertFilterExpression(t, listInput.ModelFilters[2].ValueFilters[0], "tags",
 		"tags.tag_name = ?", "special")
-	assertJoinExpression(t, listInput.ModelFilters[2].JoinCondition,"artifacts", "tags",
+	assertJoinExpression(t, listInput.ModelFilters[2].JoinCondition, "artifacts", "tags",
 		"t1", "JOIN tags t1 ON artifacts.artifact_id = t1.artifact_id")
 
 }

--- a/pkg/repositories/transformers/filters_test.go
+++ b/pkg/repositories/transformers/filters_test.go
@@ -5,21 +5,18 @@ import (
 	"testing"
 
 	"github.com/lyft/datacatalog/pkg/common"
-	"github.com/lyft/datacatalog/pkg/repositories/models"
-	datacatalog "github.com/lyft/datacatalog/protos/gen"
+	"github.com/lyft/datacatalog/protos/gen"
 	"github.com/stretchr/testify/assert"
+	"github.com/lyft/datacatalog/pkg/repositories/models"
 )
 
-func assertJoinExpression(t *testing.T, listInput models.ListModelsInput, joiningEntity common.Entity, sourceTableName string, joiningTableName string, expectedJoinStatement string) {
-	joinCondition, ok := listInput.JoinEntityToConditionMap[joiningEntity]
-	assert.True(t, ok)
-	expr, err := joinCondition.GetJoinOnDBQueryExpression(sourceTableName, joiningTableName)
+func assertJoinExpression(t *testing.T, joinCondition models.ModelJoinCondition, sourceTableName string, joiningTableName string, joiningTableAlias string, expectedJoinStatement string) {
+	expr, err := joinCondition.GetJoinOnDBQueryExpression(sourceTableName, joiningTableName, joiningTableAlias)
 	assert.NoError(t, err)
 	assert.Equal(t, expr, expectedJoinStatement)
 }
 
-func assertFilterExpression(t *testing.T, filter models.ModelValueFilter, expectedEntity common.Entity, tableName string, expectedStatement string, expectedArgs interface{}) {
-	assert.Equal(t, filter.GetDBEntity(), expectedEntity)
+func assertFilterExpression(t *testing.T, filter models.ModelValueFilter, tableName string, expectedStatement string, expectedArgs interface{}) {
 	expr, err := filter.GetDBQueryExpression(tableName)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedStatement, expr.Query)
@@ -61,20 +58,27 @@ func TestListInputWithPartitionsAndTags(t *testing.T) {
 	listInput, err := FilterToListInput(context.Background(), common.Artifact, filter)
 	assert.NoError(t, err)
 
-	// Should have 5 filters: 2 for each partition filter, 1 for tag filter
-	assert.Len(t, listInput.Filters, 5)
+	// Should have 3 filters: 2 for partitions, 1 for tag
+	assert.Len(t, listInput.ModelFilters, 3)
 
-	assertFilterExpression(t, listInput.Filters[0], common.Partition, "partitions", "partitions.key = ?", "key1")
-	assertFilterExpression(t, listInput.Filters[1], common.Partition, "partitions", "partitions.value = ?", "val1")
-	assertFilterExpression(t, listInput.Filters[2], common.Partition, "partitions", "partitions.key = ?", "key2")
-	assertFilterExpression(t, listInput.Filters[3], common.Partition, "partitions", "partitions.value = ?", "val2")
-	assertFilterExpression(t, listInput.Filters[4], common.Tag, "tags", "tags.tag_name = ?", "special")
+	assertFilterExpression(t, listInput.ModelFilters[0].ValueFilters[0],"partitions",
+		"partitions.key = ?", "key1")
+	assertFilterExpression(t, listInput.ModelFilters[0].ValueFilters[1],"partitions",
+		"partitions.value = ?", "val1")
+	assertJoinExpression(t,listInput.ModelFilters[0].JoinCondition, "artifacts", "partitions",
+		"p1", "JOIN partitions p1 ON artifacts.artifact_id = p1.artifact_id")
 
-	// even though there are 5 filters, we only need 2 joins on Partition and Tag
-	assert.Len(t, listInput.JoinEntityToConditionMap, 2)
+	assertFilterExpression(t, listInput.ModelFilters[1].ValueFilters[0], "partitions",
+		"partitions.key = ?", "key2")
+	assertFilterExpression(t, listInput.ModelFilters[1].ValueFilters[1], "partitions",
+		"partitions.value = ?", "val2")
+	assertJoinExpression(t,listInput.ModelFilters[1].JoinCondition, "artifacts", "partitions",
+		"p2", "JOIN partitions p2 ON artifacts.artifact_id = p2.artifact_id")
 
-	assertJoinExpression(t, listInput, common.Partition, "artifacts", "partitions", "JOIN partitions ON artifacts.artifact_id = partitions.artifact_id")
-	assertJoinExpression(t, listInput, common.Tag, "artifacts", "tags", "JOIN tags ON artifacts.artifact_id = tags.artifact_id")
+	assertFilterExpression(t, listInput.ModelFilters[2].ValueFilters[0], "tags",
+		"tags.tag_name = ?", "special")
+	assertJoinExpression(t, listInput.ModelFilters[2].JoinCondition,"artifacts", "tags",
+		"t1", "JOIN tags t1 ON artifacts.artifact_id = t1.artifact_id")
 
 }
 


### PR DESCRIPTION
There is a bug in the models filtering code when multiple partitions in a filter is specified. When multiple partitions (or any other filter) are specified, the resulting query only joins on one partition table, but has many where clauses. For ex: 
`Filters: [partition: {key = k1, value = v1}, partition: {key = key2, value = v2}]`

will translate to:

`select artifacts.* from artifacts join partitions on partitions.artifact_id = artifacts.artifact_id where partitions.key = k1 and partitions.value = v1 and partitions.key = k2 and partitions.value = v2`

This will render no results because a row cannot have both partition filters. The correct query would inner join a partitions table for each partition filter:

`select artifacts.* from artifacts join partitions p1 on p1.artifact_id = artifacts.artifact_id join partitions p2 on p2.artifact_id = artifacts.artifact_id where p1.key = k1 and p1.value = v1 and p2.key = k2 and p2.value = v2`

This PR achieves that by adding `join` conditions for every filter instead of having only one `join` for all filters of the same table.